### PR TITLE
Encoding fix lag_health and software_device_health

### DIFF
--- a/recommended_scripts/lag_health_monitor/lag_health_monitor.2.0.py
+++ b/recommended_scripts/lag_health_monitor/lag_health_monitor.2.0.py
@@ -22,7 +22,7 @@ The main components of the script are Manifest, Parameter Definitions and the Py
 
 - 'Manifest' defines the unique name for this script.
 - 'Parameter Definitions' defines the input parameters to the script. This script requires the following parameters: 
-    1. lag_name_1 – This parameter specifies lag name. Default value is ' '.
+    1. lag_name_1 - This parameter specifies lag name. Default value is ' '.
     2. lag_name_2 - This parameter specifies lag name. Default value is ' '.
     3. lag_name_3 - This parameter specifies lag name. Default value is ' '.
     4. lag_name_4 - This parameter specifies lag name. Default value is ' '.
@@ -40,7 +40,7 @@ The script defines Monitor(s), Condition(s) and Action(s) :
 - Conditions: 
     1. Conditions are defined to verify the transition of forwarding state of configured LAG from "true" to "false" AND blocking layer from any state to "AGGREGATION" .  
 - Actions:
-    1. Critical alert – When the monitoring condition is met, agent status is changed to Critical. A detailed Syslog message indicating the transition states and output of CLI command ('show lacp aggregate {lag_id}') is displayed  in the monitoring agent UI. 
+    1. Critical alert - When the monitoring condition is met, agent status is changed to Critical. A detailed Syslog message indicating the transition states and output of CLI command ('show lacp aggregate {lag_id}') is displayed  in the monitoring agent UI. 
     2. Normal alert -  When blocking layer and forwarding state is transitioned back to "NONE" and "true" respectively, then the agent status is set back to 'Normal'.  A Syslog message indicating the LAG status is displayed in the monitoring agent UI.
 
 This monitored data is then plotted in a time-series chart for analysis purpose.

--- a/recommended_scripts/software_device_health_monitor/software_device_health_monitor.py
+++ b/recommended_scripts/software_device_health_monitor/software_device_health_monitor.py
@@ -67,7 +67,7 @@ The main components of the script are Manifest, Parameter Definitions and python
         - The agent alert level is updated to Normal
         - A log message is generated with the rate of decrease value
         - A custom report is generated with the rate of decrease value
-    - Broadcast storm fault -​​ The user can provide the threshold value for the rate of change of broadcast packets over 20 seconds. For low sensitivity level, the threshold value is 170500, for medium sensitivity level, it is 100000 and for high sensitivity level, it is 29500. 
+    - Broadcast storm fault - The user can provide the threshold value for the rate of change of broadcast packets over 20 seconds. For low sensitivity level, the threshold value is 170500, for medium sensitivity level, it is 100000 and for high sensitivity level, it is 29500. 
         - Conditions for this monitor are -
             - When the threshold provided is for high sensitivity level and there is broadcast storm fault, the following actions are taken -​
                 - The agent status is marked as Minor, CLI commands to show interface details are executed. Syslog says 'Broadcast storm fault detected on interface <name> at high sensitivity level'.
@@ -77,7 +77,7 @@ The main components of the script are Manifest, Parameter Definitions and python
                 - The agent status is marked as Critical, CLI commands to show interface details are executed. Syslog says 'Broadcast storm fault detected on interface <name> at low sensitivity level'.
             - When there is no longer broadcast storm fault, Syslog says 'Broadcast storm fault detected on interface <name> is back to normal'.
                 - If there is no fault found on any of the interfaces, the agent status is marked as Normal.
-    - Over bandwidth fault -​​ 
+    - Over bandwidth fault -
         - Conditions for this monitor are -
             - When the threshold provided is for high sensitivity level and there is over bandwidth  fault, the following actions are taken -​
                 - The agent status is marked as Minor, CLI commands to show interface details are executed. Syslog says 'over bandwidth fault detected on interface <name> at high sensitivity level'.


### PR DESCRIPTION
Similar to the earlier fix to the connectivity_monitor.py script, the lag_health_monitor.2.0.py and software_device_health_monitor.py scripts had two non-ASCII characters in the LONG_DESCRIPTION.  This commit changes these characters to be ASCII.